### PR TITLE
Add BLUEsat's technical blog to the config

### DIFF
--- a/ros.ini
+++ b/ros.ini
@@ -150,3 +150,6 @@ name=ROSVirtual
 
 [https://discourse.ros.org/c/general.rss]
 name=ROS Discourse General
+
+[http://bluesat.com.au/feed/]
+name=BLUEsat UNSW


### PR DESCRIPTION
From #24 we regularly publish articles that relate to ROS (its a key technology in one of our projects).