### PR TITLE
Remove feeds that are no longer valid

### DIFF
--- a/ros.ini
+++ b/ros.ini
@@ -61,14 +61,8 @@ name = William Woodall
 [http://www.davidwhodo.com/feed/]
 name = David Hodo
 
-[http://kwc.org/blog/index.rdf]
-name = Ken Conley
-
 [http://www.showusyoursensors.com/feeds/posts/default]
 name = Michael Ferguson
-
-[http://www.iheartrobotics.com/feeds/posts/default]
-name = I heart robotics
 
 [http://www.ros.org/news/atom.xml]
 name = ROS news
@@ -84,9 +78,6 @@ name = ROS news
 
 #[http://www.everything-robotic.com/feeds/posts/default?alt=rss]
 #name = EVERYTHING-ROBOTIC
-
-[http://cse.unl.edu/~carrick/wordpress/?feed=rss2]
-name = Carrick Detweiler
 
 [http://mobotica.blogspot.com/feeds/posts/default?alt=rss]
 name = mobotica


### PR DESCRIPTION
Resolved #27 when combined with #28 

![image](https://user-images.githubusercontent.com/447804/51288069-53f44780-19af-11e9-9d71-d784f5baa8a8.png)

![image](https://user-images.githubusercontent.com/447804/51288086-62dafa00-19af-11e9-85a2-5f69aaa0ade7.png)

kwc redirects to feedburner, but no new ROS content since 2012 so removing.