### PR TITLE
preserve the CNAME config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
 
 script:
 - ./build.bash
-- echo 'planet.ros.org' >> output/CNAME
+- echo 'planet.ros.org'  | sudo tee output/CNAME
 
 deploy:
   provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ services:
 
 script:
 - ./build.bash
+- echo 'planet.ros.org' >> output/CNAME
 
 deploy:
   provider: pages


### PR DESCRIPTION
Because we're not keeping the history.

Removing this file breaks the CNAME alias on GitHub Pages