### PR TITLE
Clarify RSS subscription link text

### DIFF
--- a/theme/ros/index.html.tmpl
+++ b/theme/ros/index.html.tmpl
@@ -73,7 +73,7 @@
 <embed class="icon" src="./images/feed-icon.svg" type="image/svg+xml"/>
                  <br/>
                  <a class="top_button" href="./rss20.xml">
-                 Subscribe
+                 Subscribe to RSS
                  </a>
 </div>
                </td>


### PR DESCRIPTION
This PR updates the Planet ROS homepage to clarify that the subscription link points to an RSS feed.

- Replaces "Subscribe" with "Subscribe to RSS"

This follows the guidance provided in issue #47 to improve clarity without styling the RSS feed itself.
